### PR TITLE
Fix: rebalance()

### DIFF
--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -316,13 +316,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
             uint256 currentCash = totalAssetsAllocatableCache - totalAllocated;
 
             // Calculate available cash to put in strategies
-            // Fix: cash available calc
-            uint256 cashAvailable;
-            if (targetCash > currentCash) {
-                cashAvailable = targetCash - currentCash;
-            } else {
-                cashAvailable = 0;
-            }
+            uint256 cashAvailable = (currentCash > targetCash) ? currentCash - targetCash : 0;
 
             uint256 toDeposit = targetAllocation - currentAllocation;
             if (toDeposit > cashAvailable) {

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -120,7 +120,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
         _setRoleAdmin(STRATEGY_ADDER_ROLE, STRATEGY_ADDER_ROLE_ADMIN_ROLE);
         _setRoleAdmin(STRATEGY_REMOVER_ROLE, STRATEGY_REMOVER_ROLE_ADMIN_ROLE);
 
-        // Fix: increase totalAllocationPoints
+        totalAllocationPoints += _initialCashAllocationPoints;
     }
 
     /**
@@ -342,7 +342,6 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
 
     // Todo possibly allow batch harvest
     function harvest(address strategy) public nonReentrant {
-        // Fix: return if strategyData.allocated == 0
         Strategy memory strategyData = strategies[strategy];
         uint256 sharesBalance = IERC4626(strategy).balanceOf(address(this));
         uint256 underlyingBalance = IERC4626(strategy).convertToAssets(sharesBalance);

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -311,7 +311,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
             }
 
             IERC4626(strategy).withdraw(toWithdraw, address(this), address(this));
-            strategies[strategy].allocated = uint120(targetAllocation);
+            strategies[strategy].allocated = uint120(currentAllocation - toWithdraw);
             totalAllocated -= toWithdraw;
         } else if (currentAllocation < targetAllocation) {
             // Deposit

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -112,6 +112,8 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
         for (uint256 i; i < _initialStrategies.length; ++i) {
             strategies[_initialStrategies[i]] =
                 Strategy({allocated: 0, allocationPoints: uint120(_initialStrategiesAllocationPoints[i]), active: true});
+
+            totalAllocationPoints += _initialStrategiesAllocationPoints[i];
         }
 
         // Setup DEFAULT_ADMIN

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -119,6 +119,8 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
         _setRoleAdmin(WITHDRAW_QUEUE_REORDERER_ROLE, WITHDRAW_QUEUE_REORDERER_ROLE_ADMIN_ROLE);
         _setRoleAdmin(STRATEGY_ADDER_ROLE, STRATEGY_ADDER_ROLE_ADMIN_ROLE);
         _setRoleAdmin(STRATEGY_REMOVER_ROLE, STRATEGY_REMOVER_ROLE_ADMIN_ROLE);
+
+        // Fix: increase totalAllocationPoints
     }
 
     /**
@@ -314,6 +316,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
             uint256 currentCash = totalAssetsAllocatableCache - totalAllocated;
 
             // Calculate available cash to put in strategies
+            // Fix: cash available calc
             uint256 cashAvailable;
             if (targetCash > currentCash) {
                 cashAvailable = targetCash - currentCash;
@@ -345,6 +348,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
 
     // Todo possibly allow batch harvest
     function harvest(address strategy) public nonReentrant {
+        // Fix: return if strategyData.allocated == 0
         Strategy memory strategyData = strategies[strategy];
         uint256 sharesBalance = IERC4626(strategy).balanceOf(address(this));
         uint256 underlyingBalance = IERC4626(strategy).convertToAssets(sharesBalance);

--- a/test/unit/AddStrategyTest.t.sol
+++ b/test/unit/AddStrategyTest.t.sol
@@ -10,12 +10,13 @@ contract AddStrategyTest is FourSixTwoSixAggBase {
 
     function testAddStrategy() public {
         uint256 allocationPoints = 500e18;
+        uint256 totalAllocationPointsBefore = fourSixTwoSixAgg.totalAllocationPoints();
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
         _addStrategy(manager, address(eTST), allocationPoints);
 
-        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + CASH_RESERVE_ALLOCATION_POINTS);
+        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + totalAllocationPointsBefore);
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 1);
     }
 
@@ -39,12 +40,13 @@ contract AddStrategyTest is FourSixTwoSixAggBase {
 
     function testAddStrategy_AlreadyAddedStrategy() public {
         uint256 allocationPoints = 500e18;
+        uint256 totalAllocationPointsBefore = fourSixTwoSixAgg.totalAllocationPoints();
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
         _addStrategy(manager, address(eTST), allocationPoints);
 
-        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + CASH_RESERVE_ALLOCATION_POINTS);
+        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + totalAllocationPointsBefore);
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 1);
 
         vm.expectRevert();

--- a/test/unit/AddStrategyTest.t.sol
+++ b/test/unit/AddStrategyTest.t.sol
@@ -9,18 +9,18 @@ contract AddStrategyTest is FourSixTwoSixAggBase {
     }
 
     function testAddStrategy() public {
-        uint256 allocationPoints = type(uint120).max;
+        uint256 allocationPoints = 500e18;
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
         _addStrategy(manager, address(eTST), allocationPoints);
 
-        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints);
+        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + CASH_RESERVE_ALLOCATION_POINTS);
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 1);
     }
 
     function testAddStrategy_FromUnauthorizedAddress() public {
-        uint256 allocationPoints = type(uint120).max;
+        uint256 allocationPoints = 500e18;
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
@@ -29,7 +29,7 @@ contract AddStrategyTest is FourSixTwoSixAggBase {
     }
 
     function testAddStrategy_WithInvalidAsset() public {
-        uint256 allocationPoints = type(uint120).max;
+        uint256 allocationPoints = 500e18;
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
@@ -38,13 +38,13 @@ contract AddStrategyTest is FourSixTwoSixAggBase {
     }
 
     function testAddStrategy_AlreadyAddedStrategy() public {
-        uint256 allocationPoints = type(uint120).max;
+        uint256 allocationPoints = 500e18;
 
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 0);
 
         _addStrategy(manager, address(eTST), allocationPoints);
 
-        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints);
+        assertEq(fourSixTwoSixAgg.totalAllocationPoints(), allocationPoints + CASH_RESERVE_ALLOCATION_POINTS);
         assertEq(fourSixTwoSixAgg.withdrawalQueueLength(), 1);
 
         vm.expectRevert();

--- a/test/unit/FourSixTwoSixAggBase.t.sol
+++ b/test/unit/FourSixTwoSixAggBase.t.sol
@@ -5,6 +5,8 @@ import {EVaultTestBase, TestERC20} from "evk/test/unit/evault/EVaultTestBase.t.s
 import {FourSixTwoSixAgg} from "../../src/FourSixTwoSixAgg.sol";
 
 contract FourSixTwoSixAggBase is EVaultTestBase {
+    uint256 public constant CASH_RESERVE_ALLOCATION_POINTS = 1000e18;
+
     address deployer;
     address user1;
     address user2;
@@ -25,7 +27,7 @@ contract FourSixTwoSixAggBase is EVaultTestBase {
             address(assetTST),
             "assetTST_Agg",
             "assetTST_Agg",
-            type(uint120).max,
+            CASH_RESERVE_ALLOCATION_POINTS,
             new address[](0),
             new uint256[](0)
         );
@@ -49,7 +51,7 @@ contract FourSixTwoSixAggBase is EVaultTestBase {
         FourSixTwoSixAgg.Strategy memory cashReserve = fourSixTwoSixAgg.getStrategy(address(0));
 
         assertEq(cashReserve.allocated, 0);
-        assertEq(cashReserve.allocationPoints, type(uint120).max);
+        assertEq(cashReserve.allocationPoints, CASH_RESERVE_ALLOCATION_POINTS);
         assertEq(cashReserve.active, true);
 
         assertEq(


### PR DESCRIPTION
- Increase `totalAllocationPoints` by `_initialCashAllocationPoints` in constructor.
- In `Rebalance()`, decrease `strategies[strategy].allocated` by the actual withdrawn amount, instead of setting it to `targetAllocation`.
- Fix `cashAvailable` calculation.