### PR TITLE
Fix harvest() and more tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
               run: forge fmt --check    
 
             - name: Run foundry tests
-              run: forge test -vv --gas-report --ast 
+              run: FOUNDRY_PROFILE=test forge test -vv --gas-report --ast 
 
             - name: Run foundry fuzzing
               run: FOUNDRY_PROFILE=ci_fuzz forge test -vv

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,11 @@ quote_style = "double"
 number_underscore = "preserve"
 override_spacing = true
 
+[profile.test]
+no_match_test = "Fuzz"
+no_match_contract = "Fuzz"
+gas_reports = ["*"]
+
 [profile.fuzz]
 runs = 1000
 max_local_rejects = 1024

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -8,8 +8,6 @@ import {ERC4626, IERC4626} from "openzeppelin-contracts/token/ERC20/extensions/E
 import {EVCUtil, IEVC} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {AccessControlEnumerable} from "openzeppelin-contracts/access/AccessControlEnumerable.sol";
 
-import {console2} from "forge-std/Test.sol";
-
 // @note Do NOT use with fee on transfer tokens
 // @note Do NOT use with rebasing tokens
 // @note Based on https://github.com/euler-xyz/euler-vault-kit/blob/master/src/Synths/EulerSavingsRate.sol
@@ -267,15 +265,8 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
             uint256 sharesBalance = strategy.balanceOf(address(this));
             uint256 underlyingBalance = strategy.convertToAssets(sharesBalance);
 
-            console2.log("assets", assets);
-            console2.log("assetsRetrieved", assetsRetrieved);
-
             uint256 desiredAssets = assets - assetsRetrieved;
             uint256 withdrawAmount = (underlyingBalance >= desiredAssets) ? desiredAssets : underlyingBalance;
-
-            console2.log("strategyData.allocated", strategyData.allocated);
-            console2.log("withdrawAmount", withdrawAmount);
-            console2.log("totalAllocated", totalAllocated);
 
             // Update allocated assets
             strategies[withdrawalQueue[i]].allocated = strategyData.allocated - uint120(withdrawAmount);

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -8,7 +8,6 @@ import {ERC4626, IERC4626} from "openzeppelin-contracts/token/ERC20/extensions/E
 import {EVCUtil, IEVC} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {AccessControlEnumerable} from "openzeppelin-contracts/access/AccessControlEnumerable.sol";
 
-
 import {console2} from "forge-std/Test.sol";
 
 // @note Do NOT use with fee on transfer tokens
@@ -249,7 +248,7 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
     function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
         internal
         override
-    {        
+    {
         totalAssetsDeposited -= assets;
 
         uint256 assetsRetrieved = IERC20(asset()).balanceOf(address(this));

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -8,8 +8,6 @@ import {ERC4626, IERC4626} from "openzeppelin-contracts/token/ERC20/extensions/E
 import {EVCUtil, IEVC} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {AccessControlEnumerable} from "openzeppelin-contracts/access/AccessControlEnumerable.sol";
 
-import {console2} from "forge-std/Test.sol";
-
 // @note Do NOT use with fee on transfer tokens
 // @note Do NOT use with rebasing tokens
 // @note Based on https://github.com/euler-xyz/euler-vault-kit/blob/master/src/Synths/EulerSavingsRate.sol

--- a/src/FourSixTwoSixAgg.sol
+++ b/src/FourSixTwoSixAgg.sol
@@ -395,13 +395,20 @@ contract FourSixTwoSixAgg is EVCUtil, ERC4626, AccessControlEnumerable {
         }
     }
 
-    /// ToDo: possibly allow batch harvest
     /// @notice Harvest positive yield.
     /// @param strategy address of strategy
     function harvest(address strategy) public nonReentrant {
         _harvest(strategy);
 
         _gulp();
+    }
+
+    function harvestMultipleStrategies(address[] calldata _strategies) external nonReentrant {
+        for (uint256 i; i < _strategies.length; ++i) {
+            _harvest(_strategies[i]);
+
+            _gulp();
+        }
     }
 
     function _harvest(address strategy) internal {

--- a/test/common/FourSixTwoSixAggBase.t.sol
+++ b/test/common/FourSixTwoSixAggBase.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase, TestERC20, console2, EVault} from "evk/test/unit/evault/EVaultTestBase.t.sol";
+import "evk/test/unit/evault/EVaultTestBase.t.sol";
 import {FourSixTwoSixAgg} from "../../src/FourSixTwoSixAgg.sol";
 
 contract FourSixTwoSixAggBase is EVaultTestBase {

--- a/test/common/FourSixTwoSixAggBase.t.sol
+++ b/test/common/FourSixTwoSixAggBase.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {EVaultTestBase, TestERC20, console2} from "evk/test/unit/evault/EVaultTestBase.t.sol";
+import {EVaultTestBase, TestERC20, console2, EVault} from "evk/test/unit/evault/EVaultTestBase.t.sol";
 import {FourSixTwoSixAgg} from "../../src/FourSixTwoSixAgg.sol";
 
 contract FourSixTwoSixAggBase is EVaultTestBase {

--- a/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {FourSixTwoSixAggBase, FourSixTwoSixAgg, console2} from "../common/FourSixTwoSixAggBase.t.sol";
+
+contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
+    uint256 user1InitialBalance = 100000e18;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        uint256 initialStrategyAllocationPoints = 500e18;
+        _addStrategy(manager, address(eTST), initialStrategyAllocationPoints);
+
+        assetTST.mint(user1, user1InitialBalance);
+    }
+
+    function testSingleStrategy_NoYield() public {
+        uint256 amountToDeposit = 10000e18;
+
+        // deposit into aggregator
+        {
+            uint256 balanceBefore = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 userAssetBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.startPrank(user1);
+            assetTST.approve(address(fourSixTwoSixAgg), amountToDeposit);
+            fourSixTwoSixAgg.deposit(amountToDeposit, user1);
+            vm.stopPrank();
+
+            assertEq(fourSixTwoSixAgg.balanceOf(user1), balanceBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalSupply(), totalSupplyBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore + amountToDeposit);
+            assertEq(assetTST.balanceOf(user1), userAssetBalanceBefore - amountToDeposit);
+        }
+
+        // rebalance into strategy
+        vm.warp(block.timestamp + 86400);
+        {
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), strategyBefore.allocated);
+
+            uint256 expectedStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable() * strategyBefore.allocationPoints
+                / fourSixTwoSixAgg.totalAllocationPoints();
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.rebalance(address(eTST));
+
+            assertEq(fourSixTwoSixAgg.totalAllocated(), expectedStrategyCash);
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedStrategyCash);
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedStrategyCash);
+        }
+
+        vm.warp(block.timestamp + 86400);
+        // partial withdraw, no need to withdraw from strategy as cash reserve is enough
+        uint256 amountToWithdraw = 6000e18;
+        {
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            uint256 strategyShareBalanceBefore = eTST.balanceOf(address(fourSixTwoSixAgg));
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 aggregatorTotalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.withdraw(amountToWithdraw, user1, user1);
+
+            assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), strategyShareBalanceBefore);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
+            assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
+        }
+
+        // full withdraw, will have to withdraw from strategy as cash reserve is not enough
+        {
+            amountToWithdraw = amountToDeposit - amountToWithdraw;
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 aggregatorTotalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.withdraw(amountToWithdraw, user1, user1);
+
+            assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), 0);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
+            assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
+        }
+    }
+}

--- a/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {FourSixTwoSixAggBase, FourSixTwoSixAgg, console2} from "../common/FourSixTwoSixAggBase.t.sol";
+import {FourSixTwoSixAggBase, FourSixTwoSixAgg, console2, EVault} from "../common/FourSixTwoSixAggBase.t.sol";
 
 contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
     uint256 user1InitialBalance = 100000e18;
@@ -51,7 +51,9 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
 
             assertEq(fourSixTwoSixAgg.totalAllocated(), expectedStrategyCash);
             assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedStrategyCash);
-            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedStrategyCash);
+            assertEq(
+                (fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, strategyBefore.allocated + expectedStrategyCash
+            );
         }
 
         vm.warp(block.timestamp + 86400);
@@ -71,6 +73,7 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
             assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
             assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, strategyBefore.allocated);
         }
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
@@ -88,6 +91,74 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
             assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
             assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, 0);
+        }
+    }
+
+    function testSingleStrategy_WithYield() public {
+        uint256 amountToDeposit = 10000e18;
+
+        // deposit into aggregator
+        {
+            uint256 balanceBefore = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 userAssetBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.startPrank(user1);
+            assetTST.approve(address(fourSixTwoSixAgg), amountToDeposit);
+            fourSixTwoSixAgg.deposit(amountToDeposit, user1);
+            vm.stopPrank();
+
+            assertEq(fourSixTwoSixAgg.balanceOf(user1), balanceBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalSupply(), totalSupplyBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore + amountToDeposit);
+            assertEq(assetTST.balanceOf(user1), userAssetBalanceBefore - amountToDeposit);
+        }
+
+        // rebalance into strategy
+        vm.warp(block.timestamp + 86400);
+        {
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), strategyBefore.allocated);
+
+            uint256 expectedStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable() * strategyBefore.allocationPoints
+                / fourSixTwoSixAgg.totalAllocationPoints();
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.rebalance(address(eTST));
+
+            assertEq(fourSixTwoSixAgg.totalAllocated(), expectedStrategyCash);
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedStrategyCash);
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedStrategyCash);
+        }
+
+        vm.warp(block.timestamp + 86400);
+        uint256 aggrCurrentStrategyBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+        // mock an increase of strategy balance by 10%
+        vm.mockCall(
+            address(eTST),
+            abi.encodeWithSelector(EVault.balanceOf.selector, address(fourSixTwoSixAgg)),
+            abi.encode(aggrCurrentStrategyBalance * 11e17 / 1e18)
+        );
+
+        // full withdraw, will have to withdraw from strategy as cash reserve is not enough
+        {
+            uint256 amountToWithdraw = fourSixTwoSixAgg.balanceOf(user1);
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 aggregatorTotalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.redeem(amountToWithdraw, user1, user1);
+            vm.clearMockedCalls();
+
+            assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), 0);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
+            assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + fourSixTwoSixAgg.convertToAssets(amountToWithdraw));
         }
     }
 }

--- a/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
@@ -158,7 +158,10 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
             assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), 0);
             assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
             assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
-            assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + fourSixTwoSixAgg.convertToAssets(amountToWithdraw));
+            assertEq(
+                assetTST.balanceOf(user1),
+                user1AssetTSTBalanceBefore + fourSixTwoSixAgg.convertToAssets(amountToWithdraw)
+            );
         }
     }
 }

--- a/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
@@ -351,4 +351,129 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
             assertApproxEqAbs(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToDeposit + yield, 1);
         }
     }
+
+    function testMultipleStrategy_WithYield_WithInterest() public {
+        IEVault eTSTsecondary;
+        {
+            eTSTsecondary = IEVault(coreProductLine.createVault(address(assetTST), address(oracle), unitOfAccount));
+            eTSTsecondary.setInterestRateModel(address(new IRMTestDefault()));
+
+            uint256 initialStrategyAllocationPoints = 1000e18;
+            _addStrategy(manager, address(eTSTsecondary), initialStrategyAllocationPoints);
+        }
+
+        uint256 amountToDeposit = 10000e18;
+
+        // deposit into aggregator
+        {
+            uint256 balanceBefore = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 userAssetBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.startPrank(user1);
+            assetTST.approve(address(fourSixTwoSixAgg), amountToDeposit);
+            fourSixTwoSixAgg.deposit(amountToDeposit, user1);
+            vm.stopPrank();
+
+            assertEq(fourSixTwoSixAgg.balanceOf(user1), balanceBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalSupply(), totalSupplyBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore + amountToDeposit);
+            assertEq(assetTST.balanceOf(user1), userAssetBalanceBefore - amountToDeposit);
+        }
+
+        // rebalance into strategy
+        // 2500 total points; 1000 for reserve(40%), 500(20%) for eTST, 1000(40%) for eTSTsecondary
+        // 10k deposited; 4000 for reserve, 2000 for eTST, 4000 for eTSTsecondary
+        vm.warp(block.timestamp + 86400);
+        {
+            FourSixTwoSixAgg.Strategy memory eTSTstrategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            FourSixTwoSixAgg.Strategy memory eTSTsecondarystrategyBefore =
+                fourSixTwoSixAgg.getStrategy(address(eTSTsecondary));
+
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), eTSTstrategyBefore.allocated);
+            assertEq(
+                eTSTsecondary.convertToAssets(eTSTsecondary.balanceOf(address(fourSixTwoSixAgg))),
+                eTSTsecondarystrategyBefore.allocated
+            );
+
+            uint256 expectedeTSTStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable()
+                * eTSTstrategyBefore.allocationPoints / fourSixTwoSixAgg.totalAllocationPoints();
+            uint256 expectedeTSTsecondaryStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable()
+                * eTSTsecondarystrategyBefore.allocationPoints / fourSixTwoSixAgg.totalAllocationPoints();
+
+            assertTrue(expectedeTSTStrategyCash != 0);
+            assertTrue(expectedeTSTsecondaryStrategyCash != 0);
+
+            address[] memory strategiesToRebalance = new address[](2);
+            strategiesToRebalance[0] = address(eTST);
+            strategiesToRebalance[1] = address(eTSTsecondary);
+            vm.prank(user1);
+            fourSixTwoSixAgg.rebalanceMultipleStrategies(strategiesToRebalance);
+
+            assertEq(fourSixTwoSixAgg.totalAllocated(), expectedeTSTStrategyCash + expectedeTSTsecondaryStrategyCash);
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedeTSTStrategyCash);
+            assertEq(
+                eTSTsecondary.convertToAssets(eTSTsecondary.balanceOf(address(fourSixTwoSixAgg))),
+                expectedeTSTsecondaryStrategyCash
+            );
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedeTSTStrategyCash);
+            assertEq(
+                (fourSixTwoSixAgg.getStrategy(address(eTSTsecondary))).allocated, expectedeTSTsecondaryStrategyCash
+            );
+            assertEq(
+                assetTST.balanceOf(address(fourSixTwoSixAgg)),
+                amountToDeposit - (expectedeTSTStrategyCash + expectedeTSTsecondaryStrategyCash)
+            );
+        }
+
+        vm.warp(block.timestamp + 86400);
+        uint256 eTSTYield;
+        uint256 eTSTsecondaryYield;
+        {
+            // mock an increase of aggregator balance due to yield
+            uint256 aggrCurrenteTSTShareBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+            uint256 aggrCurrenteTSTUnderlyingBalance = eTST.convertToAssets(aggrCurrenteTSTShareBalance);
+            uint256 aggrCurrenteTSTsecondaryShareBalance = eTSTsecondary.balanceOf(address(fourSixTwoSixAgg));
+            uint256 aggrCurrenteTSTsecondaryUnderlyingBalance =
+                eTST.convertToAssets(aggrCurrenteTSTsecondaryShareBalance);
+            uint256 aggrNeweTSTUnderlyingBalance = aggrCurrenteTSTUnderlyingBalance * 11e17 / 1e18;
+            uint256 aggrNeweTSTsecondaryUnderlyingBalance = aggrCurrenteTSTsecondaryUnderlyingBalance * 11e17 / 1e18;
+            eTSTYield = aggrNeweTSTUnderlyingBalance - aggrCurrenteTSTUnderlyingBalance;
+            eTSTsecondaryYield = aggrNeweTSTsecondaryUnderlyingBalance - aggrCurrenteTSTsecondaryUnderlyingBalance;
+
+            assetTST.mint(address(eTST), eTSTYield);
+            assetTST.mint(address(eTSTsecondary), eTSTsecondaryYield);
+            eTST.skim(type(uint256).max, address(fourSixTwoSixAgg));
+            eTSTsecondary.skim(type(uint256).max, address(fourSixTwoSixAgg));
+        }
+
+        // harvest
+        address[] memory strategiesToHarvest = new address[](2);
+        strategiesToHarvest[0] = address(eTST);
+        strategiesToHarvest[1] = address(eTSTsecondary);
+        vm.prank(user1);
+        fourSixTwoSixAgg.harvestMultipleStrategies(strategiesToHarvest);
+        vm.warp(block.timestamp + 2 weeks);
+
+        // full withdraw, will have to withdraw from strategy as cash reserve is not enough
+        {
+            uint256 amountToWithdraw = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 aggregatorTotalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.redeem(amountToWithdraw, user1, user1);
+
+            assertApproxEqAbs(eTST.balanceOf(address(fourSixTwoSixAgg)), 0, 0);
+            assertApproxEqAbs(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw, 1);
+            assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertApproxEqAbs(
+                assetTST.balanceOf(user1),
+                user1AssetTSTBalanceBefore + amountToDeposit + eTSTYield + eTSTsecondaryYield,
+                1
+            );
+        }
+    }
 }

--- a/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceWithdrawE2ETest.t.sol
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {FourSixTwoSixAggBase, FourSixTwoSixAgg, console2, EVault} from "../common/FourSixTwoSixAggBase.t.sol";
+import {
+    FourSixTwoSixAggBase,
+    FourSixTwoSixAgg,
+    console2,
+    EVault,
+    IEVault,
+    IRMTestDefault,
+    TestERC20
+} from "../common/FourSixTwoSixAggBase.t.sol";
 
 contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
     uint256 user1InitialBalance = 100000e18;
@@ -135,13 +143,14 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
         }
 
         vm.warp(block.timestamp + 86400);
-        uint256 aggrCurrentStrategyBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
         // mock an increase of strategy balance by 10%
-        vm.mockCall(
-            address(eTST),
-            abi.encodeWithSelector(EVault.balanceOf.selector, address(fourSixTwoSixAgg)),
-            abi.encode(aggrCurrentStrategyBalance * 11e17 / 1e18)
-        );
+        uint256 aggrCurrentStrategyShareBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+        uint256 aggrCurrentStrategyUnderlyingBalance = eTST.convertToAssets(aggrCurrentStrategyShareBalance);
+        uint256 aggrNewStrategyShareBalance = aggrCurrentStrategyShareBalance * 11e17 / 1e18;
+        uint256 aggrNewStrategyUnderlyingBalance = aggrCurrentStrategyUnderlyingBalance * 11e17 / 1e18;
+        uint256 yield = aggrNewStrategyUnderlyingBalance - aggrCurrentStrategyUnderlyingBalance;
+        assetTST.mint(address(eTST), yield);
+        eTST.skim(type(uint256).max, address(fourSixTwoSixAgg));
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
         {
@@ -153,7 +162,118 @@ contract DepositRebalanceWithdrawE2ETest is FourSixTwoSixAggBase {
 
             vm.prank(user1);
             fourSixTwoSixAgg.redeem(amountToWithdraw, user1, user1);
-            vm.clearMockedCalls();
+
+            assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), yield);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
+            assertEq(fourSixTwoSixAgg.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(
+                assetTST.balanceOf(user1),
+                user1AssetTSTBalanceBefore + fourSixTwoSixAgg.convertToAssets(amountToWithdraw)
+            );
+        }
+    }
+
+    function testMultipleStrategy_WithYield() public {
+        IEVault eTSTsecondary;
+        {
+            eTSTsecondary = IEVault(coreProductLine.createVault(address(assetTST), address(oracle), unitOfAccount));
+            eTSTsecondary.setInterestRateModel(address(new IRMTestDefault()));
+
+            uint256 initialStrategyAllocationPoints = 1000e18;
+            _addStrategy(manager, address(eTSTsecondary), initialStrategyAllocationPoints);
+        }
+
+        uint256 amountToDeposit = 10000e18;
+
+        // deposit into aggregator
+        {
+            uint256 balanceBefore = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 userAssetBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.startPrank(user1);
+            assetTST.approve(address(fourSixTwoSixAgg), amountToDeposit);
+            fourSixTwoSixAgg.deposit(amountToDeposit, user1);
+            vm.stopPrank();
+
+            assertEq(fourSixTwoSixAgg.balanceOf(user1), balanceBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalSupply(), totalSupplyBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore + amountToDeposit);
+            assertEq(assetTST.balanceOf(user1), userAssetBalanceBefore - amountToDeposit);
+        }
+
+        // rebalance into strategy
+        // 2500 total points; 1000 for reserve(40%), 500(20%) for eTST, 1000(40%) for eTSTsecondary
+        // 10k deposited; 4000 for reserve, 2000 for eTST, 4000 for eTSTsecondary
+        vm.warp(block.timestamp + 86400);
+        {
+            FourSixTwoSixAgg.Strategy memory eTSTstrategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            FourSixTwoSixAgg.Strategy memory eTSTsecondarystrategyBefore =
+                fourSixTwoSixAgg.getStrategy(address(eTSTsecondary));
+
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), eTSTstrategyBefore.allocated);
+            assertEq(
+                eTSTsecondary.convertToAssets(eTSTsecondary.balanceOf(address(fourSixTwoSixAgg))),
+                eTSTsecondarystrategyBefore.allocated
+            );
+
+            uint256 expectedeTSTStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable()
+                * eTSTstrategyBefore.allocationPoints / fourSixTwoSixAgg.totalAllocationPoints();
+            uint256 expectedeTSTsecondaryStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable()
+                * eTSTsecondarystrategyBefore.allocationPoints / fourSixTwoSixAgg.totalAllocationPoints();
+
+            assertTrue(expectedeTSTStrategyCash != 0);
+            assertTrue(expectedeTSTsecondaryStrategyCash != 0);
+
+            address[] memory strategiesToRebalance = new address[](2);
+            strategiesToRebalance[0] = address(eTST);
+            strategiesToRebalance[1] = address(eTSTsecondary);
+            vm.prank(user1);
+            fourSixTwoSixAgg.rebalanceMultipleStrategies(strategiesToRebalance);
+
+            assertEq(fourSixTwoSixAgg.totalAllocated(), expectedeTSTStrategyCash + expectedeTSTsecondaryStrategyCash);
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedeTSTStrategyCash);
+            assertEq(
+                eTSTsecondary.convertToAssets(eTSTsecondary.balanceOf(address(fourSixTwoSixAgg))),
+                expectedeTSTsecondaryStrategyCash
+            );
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedeTSTStrategyCash);
+            assertEq(
+                (fourSixTwoSixAgg.getStrategy(address(eTSTsecondary))).allocated, expectedeTSTsecondaryStrategyCash
+            );
+            assertEq(
+                assetTST.balanceOf(address(fourSixTwoSixAgg)),
+                amountToDeposit - (expectedeTSTStrategyCash + expectedeTSTsecondaryStrategyCash)
+            );
+        }
+
+        vm.warp(block.timestamp + 86400);
+        // mock an increase of aggregator balance due to yield
+        uint256 aggrCurrenteTSTShareBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+        uint256 aggrCurrenteTSTUnderlyingBalance = eTST.convertToAssets(aggrCurrenteTSTShareBalance);
+        uint256 aggrCurrenteTSTsecondaryShareBalance = eTSTsecondary.balanceOf(address(fourSixTwoSixAgg));
+        uint256 aggrCurrenteTSTsecondaryUnderlyingBalance = eTST.convertToAssets(aggrCurrenteTSTsecondaryShareBalance);
+        uint256 aggrNeweTSTUnderlyingBalance = aggrCurrenteTSTUnderlyingBalance * 11e17 / 1e18;
+        uint256 aggrNeweTSTsecondaryUnderlyingBalance = aggrCurrenteTSTsecondaryUnderlyingBalance * 11e17 / 1e18;
+        uint256 eTSTYield = aggrNeweTSTUnderlyingBalance - aggrCurrenteTSTUnderlyingBalance;
+        uint256 eTSTsecondaryYield = aggrNeweTSTsecondaryUnderlyingBalance - aggrCurrenteTSTsecondaryUnderlyingBalance;
+
+        assetTST.mint(address(eTST), eTSTYield);
+        assetTST.mint(address(eTSTsecondary), eTSTsecondaryYield);
+        eTST.skim(type(uint256).max, address(fourSixTwoSixAgg));
+        eTSTsecondary.skim(type(uint256).max, address(fourSixTwoSixAgg));
+
+        // full withdraw, will have to withdraw from strategy as cash reserve is not enough
+        {
+            uint256 amountToWithdraw = fourSixTwoSixAgg.balanceOf(user1);
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 aggregatorTotalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.redeem(amountToWithdraw, user1, user1);
 
             assertEq(eTST.balanceOf(address(fourSixTwoSixAgg)), 0);
             assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);

--- a/test/unit/HarvestTest.t.sol
+++ b/test/unit/HarvestTest.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {FourSixTwoSixAggBase, FourSixTwoSixAgg, console2, EVault} from "../common/FourSixTwoSixAggBase.t.sol";
+
+contract HarvestTest is FourSixTwoSixAggBase {
+    uint256 user1InitialBalance = 100000e18;
+    uint256 amountToDeposit = 10000e18;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        uint256 initialStrategyAllocationPoints = 500e18;
+        _addStrategy(manager, address(eTST), initialStrategyAllocationPoints);
+
+        assetTST.mint(user1, user1InitialBalance);
+
+        // deposit into aggregator
+        {
+            uint256 balanceBefore = fourSixTwoSixAgg.balanceOf(user1);
+            uint256 totalSupplyBefore = fourSixTwoSixAgg.totalSupply();
+            uint256 totalAssetsDepositedBefore = fourSixTwoSixAgg.totalAssetsDeposited();
+            uint256 userAssetBalanceBefore = assetTST.balanceOf(user1);
+
+            vm.startPrank(user1);
+            assetTST.approve(address(fourSixTwoSixAgg), amountToDeposit);
+            fourSixTwoSixAgg.deposit(amountToDeposit, user1);
+            vm.stopPrank();
+
+            assertEq(fourSixTwoSixAgg.balanceOf(user1), balanceBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalSupply(), totalSupplyBefore + amountToDeposit);
+            assertEq(fourSixTwoSixAgg.totalAssetsDeposited(), totalAssetsDepositedBefore + amountToDeposit);
+            assertEq(assetTST.balanceOf(user1), userAssetBalanceBefore - amountToDeposit);
+        }
+
+        // rebalance into strategy
+        vm.warp(block.timestamp + 86400);
+        {
+            FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), strategyBefore.allocated);
+
+            uint256 expectedStrategyCash = fourSixTwoSixAgg.totalAssetsAllocatable() * strategyBefore.allocationPoints
+                / fourSixTwoSixAgg.totalAllocationPoints();
+
+            vm.prank(user1);
+            fourSixTwoSixAgg.rebalance(address(eTST));
+
+            assertEq(fourSixTwoSixAgg.totalAllocated(), expectedStrategyCash);
+            assertEq(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))), expectedStrategyCash);
+            assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, expectedStrategyCash);
+        }
+    }
+
+    function testHarvest() public {
+        // no yield increase
+        FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+        uint256 totalAllocatedBefore = fourSixTwoSixAgg.totalAllocated();
+
+        assertTrue(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))) == strategyBefore.allocated);
+
+        vm.prank(user1);
+        fourSixTwoSixAgg.harvest(address(eTST));
+
+        assertEq((fourSixTwoSixAgg.getStrategy(address(eTST))).allocated, strategyBefore.allocated);
+        assertEq(fourSixTwoSixAgg.totalAllocated(), totalAllocatedBefore);
+
+        // positive yield
+        vm.warp(block.timestamp + 86400);
+
+        // mock an increase of strategy balance by 10%
+        uint256 aggrCurrentStrategyBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+        vm.mockCall(
+            address(eTST),
+            abi.encodeWithSelector(EVault.balanceOf.selector, address(fourSixTwoSixAgg)),
+            abi.encode(aggrCurrentStrategyBalance * 11e17 / 1e18)
+        );
+
+        assertTrue(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))) > strategyBefore.allocated);
+
+        vm.prank(user1);
+        fourSixTwoSixAgg.harvest(address(eTST));
+
+        assertEq(
+            (fourSixTwoSixAgg.getStrategy(address(eTST))).allocated,
+            eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg)))
+        );
+        assertEq(
+            fourSixTwoSixAgg.totalAllocated(),
+            totalAllocatedBefore
+                + (eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))) - strategyBefore.allocated)
+        );
+    }
+
+    function testHarvestNegativeYield() public {
+        vm.warp(block.timestamp + 86400);
+
+        // mock an increase of strategy balance by 10%
+        uint256 aggrCurrentStrategyBalance = eTST.balanceOf(address(fourSixTwoSixAgg));
+        vm.mockCall(
+            address(eTST),
+            abi.encodeWithSelector(EVault.balanceOf.selector, address(fourSixTwoSixAgg)),
+            abi.encode(aggrCurrentStrategyBalance * 9e17 / 1e18)
+        );
+
+        FourSixTwoSixAgg.Strategy memory strategyBefore = fourSixTwoSixAgg.getStrategy(address(eTST));
+
+        assertTrue(eTST.convertToAssets(eTST.balanceOf(address(fourSixTwoSixAgg))) < strategyBefore.allocated);
+
+        vm.startPrank(user1);
+        vm.expectRevert(FourSixTwoSixAgg.NegativeYield.selector);
+        fourSixTwoSixAgg.harvest(address(eTST));
+    }
+}


### PR DESCRIPTION
- Add internal functions to avoid re-entrancy protection.
- e2e and unit tests.
- Add `harvestMultipleStrategies()` and `rebalanceMultipleStrategies()`.
- Fix rebalance: load `strategyData` after harvesting and gulping.
-  Update harvest: revert only on negative yield, if no yield, just return.