### PR TITLE
clean: withdrawAmount should already be accurate

### DIFF
--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -327,9 +327,6 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
                 // Do actual withdraw from strategy
                 strategy.withdraw(withdrawAmount, address(this), address(this));
 
-                // update withdrawAmount as in some cases we may not get that amount withdrawn.
-                withdrawAmount = IERC20(asset()).balanceOf(address(this)) - assetsRetrieved;
-
                 // Update allocated assets
                 $.strategies[address(strategy)].allocated -= uint120(withdrawAmount);
                 $.totalAllocated -= withdrawAmount;


### PR DESCRIPTION
**Merge after merging #55**

Removing the double check of how much was actually withdrawn from a strategy as `withdrawAmount` should already be accurate: either the returned amount from `.maxWithdraw()` or `desiredAssets`.

Fix LEND-431