### PR TITLE
feat: enable the disabling of reward for non-active strategy

### DIFF
--- a/src/module/Rewards.sol
+++ b/src/module/Rewards.sol
@@ -65,12 +65,6 @@ abstract contract RewardsModule is IBalanceForwarder, Shared {
         virtual
         nonReentrant
     {
-        YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
-
-        if ($.strategies[_strategy].status == IYieldAggregator.StrategyStatus.Inactive) {
-            revert Errors.StrategyShouldBeActive();
-        }
-
         IRewardStreams(IBalanceForwarder(_strategy).balanceTrackerAddress()).disableReward(
             _strategy, _reward, _forfeitRecentReward
         );

--- a/test/e2e/StrategyRewardsE2ETest.t.sol
+++ b/test/e2e/StrategyRewardsE2ETest.t.sol
@@ -173,7 +173,6 @@ contract StrategyRewardsE2ETest is YieldAggregatorBase {
         eulerYieldAggregatorVault.enableRewardForStrategy(address(eTST), address(assetTST));
 
         vm.prank(manager);
-        vm.expectRevert(ErrorsLib.StrategyShouldBeActive.selector);
         eulerYieldAggregatorVault.disableRewardForStrategy(address(nonActiveStrategy), address(assetTST), true);
 
         vm.expectEmit();


### PR DESCRIPTION
**Merge only after merging #57**

`disableRewardForStrategy()` was reverting in the case of an inactive strategy. We should allow it in case aggregator manager want to disable reward for a strategy that was already removed, or in the case of a strategy in emergency status.

Fix LEND-433