### PR TITLE
[zAudit-fix-4]Simulate harvest during previewWithdraw() & previewRedeem()

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 libs = ["lib"]
 test = 'test'
 optimizer = true
-optimizer_runs = 10_000
+optimizer_runs = 1_000
 solc = "0.8.24"
 gas_reports = ["*"]
 fs_permissions = [{ access = "read", path = "./"}]

--- a/src/common/Shared.sol
+++ b/src/common/Shared.sol
@@ -40,7 +40,7 @@ abstract contract Shared is EVCUtil {
         YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
 
         uint256 totalAssetsDepositedCache = $.totalAssetsDeposited;
-        uint256 totalNotDistributed = _totalAssetsAllocatable($.totalAllocated) - totalAssetsDepositedCache;
+        uint256 totalNotDistributed = _totalAssetsAllocatable() - totalAssetsDepositedCache;
 
         // set interestLeft to zero, will be updated to the right value during _gulp()
         $.interestLeft = 0;
@@ -73,12 +73,12 @@ abstract contract Shared is EVCUtil {
     function _gulp() internal {
         _updateInterestAccrued();
 
-        YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
-
         // Do not gulp if total supply is too low
         if (_totalSupply() < Constants.MIN_SHARES_FOR_GULP) return;
 
-        uint256 toGulp = _totalAssetsAllocatable($.totalAllocated) - $.totalAssetsDeposited - $.interestLeft;
+        YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
+
+        uint256 toGulp = _totalAssetsAllocatable() - $.totalAssetsDeposited - $.interestLeft;
         if (toGulp == 0) return;
 
         uint256 maxGulp = type(uint168).max - $.interestLeft;
@@ -136,8 +136,10 @@ abstract contract Shared is EVCUtil {
     /// @dev Return total assets allocatable.
     /// @dev The total assets allocatable is the current balanceOf + total amount already allocated.
     /// @return total assets allocatable.
-    function _totalAssetsAllocatable(uint256 _totalAllocated) internal view returns (uint256) {
-        return IERC20(IERC4626(address(this)).asset()).balanceOf(address(this)) + _totalAllocated;
+    function _totalAssetsAllocatable() internal view returns (uint256) {
+        YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
+
+        return IERC20(IERC4626(address(this)).asset()).balanceOf(address(this)) + $.totalAllocated;
     }
 
     /// @dev Override for _msgSender() to use the EVC authentication.

--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -665,7 +665,7 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
             uint96 cachedPerformanceFee = $.performanceFee;
 
             if ($.feeRecipient != address(0) && cachedPerformanceFee != 0) {
-                uint256 yield = totalNegativeYield - totalPositiveYield;
+                uint256 yield = totalPositiveYield - totalNegativeYield;
                 (uint256 feeAssets, uint256 feeShares) = _applyPerformanceFee(yield, cachedPerformanceFee);
 
                 totalAssetsDepositedExpected += feeAssets;

--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -262,10 +262,10 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
     /// @dev See {IERC4626-previewWithdraw}.
     /// @return Amount of shares.
     function previewWithdraw(uint256 _assets) public view virtual override nonReentrantView returns (uint256) {
-        (uint256 totalAssetsDepositedExpected, uint256 totalSupplyExpected) = previewHarvest();
+        (uint256 totalAssetsExpected, uint256 totalSupplyExpected) = previewHarvest();
 
         return _assets.mulDiv(
-            totalSupplyExpected + 10 ** _decimalsOffset(), totalAssetsDepositedExpected + 1, Math.Rounding.Ceil
+            totalSupplyExpected + 10 ** _decimalsOffset(), totalAssetsExpected + 1, Math.Rounding.Ceil
         );
     }
 
@@ -273,7 +273,9 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
     /// @dev See {IERC4626-previewRedeem}.
     /// @return Amount of assets.
     function previewRedeem(uint256 _shares) public view virtual override nonReentrantView returns (uint256) {
-        return _convertToAssets(_shares, Math.Rounding.Floor);
+        (uint256 totalAssetsExpected, uint256 totalSupplyExpected) = previewHarvest();
+
+        return _shares.mulDiv(totalAssetsExpected + 1, totalSupplyExpected + 10 ** _decimalsOffset(), Math.Rounding.Floor);
     }
 
     /// @notice Return the `_account` aggregator's balance.

--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -264,9 +264,8 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
     function previewWithdraw(uint256 _assets) public view virtual override nonReentrantView returns (uint256) {
         (uint256 totalAssetsExpected, uint256 totalSupplyExpected) = previewHarvest();
 
-        return _assets.mulDiv(
-            totalSupplyExpected + 10 ** _decimalsOffset(), totalAssetsExpected + 1, Math.Rounding.Ceil
-        );
+        return
+            _assets.mulDiv(totalSupplyExpected + 10 ** _decimalsOffset(), totalAssetsExpected + 1, Math.Rounding.Ceil);
     }
 
     /// @notice Preview a redeem call and return the amount of assets to be withdrawn.
@@ -275,7 +274,8 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
     function previewRedeem(uint256 _shares) public view virtual override nonReentrantView returns (uint256) {
         (uint256 totalAssetsExpected, uint256 totalSupplyExpected) = previewHarvest();
 
-        return _shares.mulDiv(totalAssetsExpected + 1, totalSupplyExpected + 10 ** _decimalsOffset(), Math.Rounding.Floor);
+        return
+            _shares.mulDiv(totalAssetsExpected + 1, totalSupplyExpected + 10 ** _decimalsOffset(), Math.Rounding.Floor);
     }
 
     /// @notice Return the `_account` aggregator's balance.

--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -205,9 +205,7 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
     /// @dev the total assets allocatable is the amount of assets deposited into the aggregator + assets already deposited into strategies
     /// @return total assets allocatable.
     function totalAssetsAllocatable() public view virtual nonReentrantView returns (uint256) {
-        YieldAggregatorStorage storage $ = Storage._getYieldAggregatorStorage();
-
-        return _totalAssetsAllocatable($.totalAllocated);
+        return _totalAssetsAllocatable();
     }
 
     /// @notice Return the total amount of assets deposited, plus the accrued interest.
@@ -551,7 +549,7 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
         if (strategyData.status != IYieldAggregator.StrategyStatus.Active) return;
 
         uint256 totalAllocationPointsCache = $.totalAllocationPoints;
-        uint256 totalAssetsAllocatableCache = _totalAssetsAllocatable($.totalAllocated);
+        uint256 totalAssetsAllocatableCache = _totalAssetsAllocatable();
         uint256 targetAllocation =
             totalAssetsAllocatableCache * strategyData.allocationPoints / totalAllocationPointsCache;
 
@@ -656,7 +654,7 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
         if (totalNegativeYield > totalPositiveYield) {
             interestLeftExpected = 0;
 
-            uint256 totalNotDistributed = _totalAssetsAllocatable($.totalAllocated) - totalAssetsDepositedExpected;
+            uint256 totalNotDistributed = _totalAssetsAllocatable() - totalAssetsDepositedExpected;
             uint256 lossAmount = totalNegativeYield - totalPositiveYield;
             if (lossAmount > totalNotDistributed) {
                 lossAmount -= totalNotDistributed;

--- a/test/e2e/DepositRebalanceHarvestWithdrawE2ETest.t.sol
+++ b/test/e2e/DepositRebalanceHarvestWithdrawE2ETest.t.sol
@@ -69,14 +69,17 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedShares = eulerYieldAggregatorVault.previewWithdraw(amountToWithdraw);
             vm.prank(user1);
-            eulerYieldAggregatorVault.withdraw(amountToWithdraw, user1, user1);
+            uint256 burnedShares = eulerYieldAggregatorVault.withdraw(amountToWithdraw, user1, user1);
 
             assertEq(eTST.balanceOf(address(eulerYieldAggregatorVault)), strategyShareBalanceBefore);
             assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
             assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
             assertEq((eulerYieldAggregatorVault.getStrategy(address(eTST))).allocated, strategyBefore.allocated);
+
+            assertEq(burnedShares, previewedShares);
         }
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
@@ -86,14 +89,17 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedShares = eulerYieldAggregatorVault.previewWithdraw(amountToWithdraw);
             vm.prank(user1);
-            eulerYieldAggregatorVault.withdraw(amountToWithdraw, user1, user1);
+            uint256 burnedShares = eulerYieldAggregatorVault.withdraw(amountToWithdraw, user1, user1);
 
             assertEq(eTST.balanceOf(address(eulerYieldAggregatorVault)), 0);
             assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
             assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToWithdraw);
             assertEq((eulerYieldAggregatorVault.getStrategy(address(eTST))).allocated, 0);
+
+            assertEq(previewedShares, burnedShares);
         }
     }
 
@@ -149,21 +155,24 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
         {
-            uint256 amountToWithdraw = eulerYieldAggregatorVault.balanceOf(user1);
+            uint256 amountToRedeem = eulerYieldAggregatorVault.balanceOf(user1);
             uint256 totalAssetsDepositedBefore = eulerYieldAggregatorVault.totalAssetsDeposited();
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToRedeem);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToRedeem, user1, user1);
 
             assertEq(eTST.balanceOf(address(eulerYieldAggregatorVault)), yield);
-            assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
-            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToRedeem);
+            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToRedeem);
             assertEq(
                 assetTST.balanceOf(user1),
-                user1AssetTSTBalanceBefore + eulerYieldAggregatorVault.convertToAssets(amountToWithdraw)
+                user1AssetTSTBalanceBefore + eulerYieldAggregatorVault.convertToAssets(amountToRedeem)
             );
+
+            assertEq(previewedAssets, withdrawnAssets);
         }
     }
 
@@ -272,21 +281,24 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
         {
-            uint256 amountToWithdraw = eulerYieldAggregatorVault.balanceOf(user1);
+            uint256 amountToRedeem = eulerYieldAggregatorVault.balanceOf(user1);
             uint256 totalAssetsDepositedBefore = eulerYieldAggregatorVault.totalAssetsDeposited();
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToRedeem);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToRedeem, user1, user1);
 
             assertEq(eTST.balanceOf(address(eulerYieldAggregatorVault)), 0);
-            assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw);
-            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToRedeem);
+            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToRedeem);
             assertEq(
                 assetTST.balanceOf(user1),
-                user1AssetTSTBalanceBefore + eulerYieldAggregatorVault.convertToAssets(amountToWithdraw)
+                user1AssetTSTBalanceBefore + eulerYieldAggregatorVault.convertToAssets(amountToRedeem)
             );
+
+            assertEq(previewedAssets, withdrawnAssets);
         }
     }
 
@@ -347,21 +359,24 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
         {
-            uint256 amountToWithdraw = eulerYieldAggregatorVault.balanceOf(user1);
+            uint256 amountToRedeem = eulerYieldAggregatorVault.balanceOf(user1);
             uint256 totalAssetsDepositedBefore = eulerYieldAggregatorVault.totalAssetsDeposited();
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToRedeem);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToRedeem, user1, user1);
 
             // all yield is distributed
             assertApproxEqAbs(eTST.balanceOf(address(eulerYieldAggregatorVault)), 0, 1);
             assertApproxEqAbs(
-                eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw, 1
+                eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToRedeem, 1
             );
-            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToRedeem);
             assertApproxEqAbs(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + amountToDeposit + yield, 1);
+
+            assertEq(previewedAssets, withdrawnAssets);
         }
     }
 
@@ -480,24 +495,27 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
 
         // full withdraw, will have to withdraw from strategy as cash reserve is not enough
         {
-            uint256 amountToWithdraw = eulerYieldAggregatorVault.balanceOf(user1);
+            uint256 amountToRedeem = eulerYieldAggregatorVault.balanceOf(user1);
             uint256 totalAssetsDepositedBefore = eulerYieldAggregatorVault.totalAssetsDeposited();
             uint256 aggregatorTotalSupplyBefore = eulerYieldAggregatorVault.totalSupply();
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToRedeem);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToRedeem, user1, user1);
 
             assertApproxEqAbs(eTST.balanceOf(address(eulerYieldAggregatorVault)), 0, 0);
             assertApproxEqAbs(
-                eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToWithdraw, 1
+                eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - amountToRedeem, 1
             );
-            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
+            assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToRedeem);
             assertApproxEqAbs(
                 assetTST.balanceOf(user1),
                 user1AssetTSTBalanceBefore + amountToDeposit + eTSTYield + eTSTsecondaryYield,
                 1
             );
+
+            assertEq(previewedAssets, withdrawnAssets);
         }
     }
 
@@ -562,6 +580,9 @@ contract DepositRebalanceHarvestWithdrawE2ETest is YieldAggregatorBase {
         );
 
         uint256 amountToRedeem = eulerYieldAggregatorVault.balanceOf(user1);
+        uint256 previewedShares = eulerYieldAggregatorVault.previewWithdraw(amountToDeposit);
+        assertEq(amountToRedeem, previewedShares);
+
         vm.prank(user1);
         vm.expectRevert(ErrorsLib.NotEnoughAssets.selector);
         eulerYieldAggregatorVault.redeem(amountToRedeem, user1, user1);

--- a/test/e2e/HarvestRedeemE2ETest.t.sol
+++ b/test/e2e/HarvestRedeemE2ETest.t.sol
@@ -78,9 +78,9 @@ contract HarvestRedeemE2ETest is YieldAggregatorBase {
             user1SharesBefore * amountToDeposit / eulerYieldAggregatorVault.totalSupply() - user1SocializedLoss;
         uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
 
+        uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(user1SharesBefore);
         vm.startPrank(user1);
-        eulerYieldAggregatorVault.harvest();
-        eulerYieldAggregatorVault.redeem(user1SharesBefore, user1, user1);
+        uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(user1SharesBefore, user1, user1);
         vm.stopPrank();
 
         uint256 user1SharesAfter = eulerYieldAggregatorVault.balanceOf(user1);
@@ -88,6 +88,7 @@ contract HarvestRedeemE2ETest is YieldAggregatorBase {
         assertEq(user1SharesAfter, 0);
         assertApproxEqAbs(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + expectedUser1Assets, 1);
         assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), 0);
+        assertEq(previewedAssets, withdrawnAssets);
     }
 
     function testHarvestNegativeYieldAndRedeemMultipleUser() public {
@@ -130,13 +131,18 @@ contract HarvestRedeemE2ETest is YieldAggregatorBase {
         uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
         uint256 user2AssetTSTBalanceBefore = assetTST.balanceOf(user2);
 
+        uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(user1SharesBefore);
         vm.startPrank(user1);
-        eulerYieldAggregatorVault.harvest();
-        eulerYieldAggregatorVault.redeem(user1SharesBefore, user1, user1);
+        uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(user1SharesBefore, user1, user1);
         vm.stopPrank();
 
+        assertEq(previewedAssets, withdrawnAssets);
+
+        previewedAssets = eulerYieldAggregatorVault.previewRedeem(user2SharesBefore);
         vm.prank(user2);
-        eulerYieldAggregatorVault.redeem(user2SharesBefore, user2, user2);
+        withdrawnAssets = eulerYieldAggregatorVault.redeem(user2SharesBefore, user2, user2);
+
+        assertEq(previewedAssets, withdrawnAssets);
 
         uint256 user1SharesAfter = eulerYieldAggregatorVault.balanceOf(user1);
         uint256 user2SharesAfter = eulerYieldAggregatorVault.balanceOf(user2);

--- a/test/e2e/PerformanceFeeE2ETest.t.sol
+++ b/test/e2e/PerformanceFeeE2ETest.t.sol
@@ -103,6 +103,8 @@ contract PerformanceFeeE2ETest is YieldAggregatorBase {
         IYieldAggregator.Strategy memory strategyBeforeHarvest = eulerYieldAggregatorVault.getStrategy(address(eTST));
         uint256 totalAllocatedBefore = eulerYieldAggregatorVault.totalAllocated();
 
+        uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(eulerYieldAggregatorVault.balanceOf(user1));
+
         // harvest
         vm.prank(user1);
         eulerYieldAggregatorVault.harvest();
@@ -125,13 +127,14 @@ contract PerformanceFeeE2ETest is YieldAggregatorBase {
                 eulerYieldAggregatorVault.convertToAssets(eulerYieldAggregatorVault.balanceOf(user1));
 
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
 
             assertApproxEqAbs(
                 eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - expectedAssetTST, 1
             );
             assertEq(eulerYieldAggregatorVault.totalSupply(), aggregatorTotalSupplyBefore - amountToWithdraw);
             assertApproxEqAbs(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + expectedAssetTST, 1);
+            assertEq(withdrawnAssets, previewedAssets);
         }
 
         // full redemption of recipient fees

--- a/test/e2e/ToggleStrategyEmergencyStatusE2ETest.t.sol
+++ b/test/e2e/ToggleStrategyEmergencyStatusE2ETest.t.sol
@@ -151,13 +151,15 @@ contract ToggleStrategyEmergencyStatusE2ETest is YieldAggregatorBase {
             uint256 user1AssetTSTBalanceBefore = assetTST.balanceOf(user1);
             uint256 expectedAssets = eulerYieldAggregatorVault.convertToAssets(amountToWithdraw);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToWithdraw);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
 
             assertTrue(eTST.balanceOf(address(eulerYieldAggregatorVault)) != 0);
             assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), 0);
             assertEq(eulerYieldAggregatorVault.totalSupply(), 0);
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + expectedAssets);
+            assertEq(previewedAssets, withdrawnAssets);
         }
     }
 
@@ -263,14 +265,16 @@ contract ToggleStrategyEmergencyStatusE2ETest is YieldAggregatorBase {
 
             assertTrue(totalAssetsDepositedBefore != 0);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToWithdraw);
             vm.prank(user1);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToWithdraw, user1, user1);
 
             assertTrue(eTST.balanceOf(address(eulerYieldAggregatorVault)) != 0);
             assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), totalAssetsDepositedBefore - expectedAssets);
             assertEq(eulerYieldAggregatorVault.totalSupply(), eulerYieldAggregatorVault.balanceOf(user2));
             assertEq(assetTST.balanceOf(user1), user1AssetTSTBalanceBefore + expectedAssets);
             assertEq(assetTST.balanceOf(user2), user2AssetTSTBalanceBefore);
+            assertEq(previewedAssets, withdrawnAssets);
         }
 
         vm.warp(block.timestamp + 86400);
@@ -295,13 +299,15 @@ contract ToggleStrategyEmergencyStatusE2ETest is YieldAggregatorBase {
 
             assertTrue(totalAssetsDepositedBefore != 0);
 
+            uint256 previewedAssets = eulerYieldAggregatorVault.previewRedeem(amountToWithdraw);
             vm.prank(user2);
-            eulerYieldAggregatorVault.redeem(amountToWithdraw, user2, user2);
+            uint256 withdrawnAssets = eulerYieldAggregatorVault.redeem(amountToWithdraw, user2, user2);
 
             assertEq(eTST.balanceOf(address(eulerYieldAggregatorVault)), 0);
             assertEq(eulerYieldAggregatorVault.totalAssetsDeposited(), 0);
             assertEq(eulerYieldAggregatorVault.totalSupply(), 0);
             assertEq(assetTST.balanceOf(user2), user2AssetTSTBalanceBefore + expectedAssets);
+            assertEq(previewedAssets, withdrawnAssets);
         }
 
         IYieldAggregator.Strategy memory eTSTsecondaryStrategy =


### PR DESCRIPTION
**Merge only after merging #60**

This PR implements a `previewHarvest()` function that will simulate an actual harvest flow, and returns the expected `_totalAssets()` and `_totalSupply()` amounts after a harvest.
Those two returned amounts are used in `previewWithdraw()` and `previewRedeem()` to return correct amount of shares and assets as if an actual withdraw/redeem was called. (ignoring any limits that could occurs from underlying strategies)

`previewHarvest()` simulate the following flow:
- `totalAssetsDepositedExpected = totalAssetsDeposited`
-  `totalSupplyExpected = _totalSupply()`
-  `interestLeftExpected = interestLeft`
- If no harvest:
  - `_totalAssets() == totalAssetsDepositedExpected + _interestAccruedFromCache(interestLeftExpected)`.
  - `_totalSupply() == totalSupplyExpected`
- If there is harvest:
  - Net positive yield:
    - If performance fee is on:
      -  `totalAssetsDepositedExpected` += feeAssets
      -  `totalSupplyExpected` += feeShares
    -  `_totalAssets() == totalAssetsDepositedExpected + _interestAccruedFromCache(interestLeftExpected)`.
    - `_totalSupply() == totalSupplyExpected`
  - Net negative yield:
    - `interestLeftExpected = 0`
    -  `lossAmount > totalNotDistributed` then `totalAssetsDepositedExpected -= lossAmount - totalNotDistributed`
    -  `_totalAssets() == totalAssetsDepositedExpected` as `_interestAccruedFromCache(interestLeftExpected) == 0`
    - `_totalSupply() == totalSupplyExpected`
