### PR TITLE
[zAudit-fix-6]Remove external call to asset()

### DIFF
--- a/src/module/Strategy.sol
+++ b/src/module/Strategy.sol
@@ -120,7 +120,7 @@ abstract contract StrategyModule is Shared {
             revert Errors.StrategyAlreadyExist();
         }
 
-        if (IERC4626(_strategy).asset() != IERC4626(address(this)).asset()) {
+        if (IERC4626(_strategy).asset() != _asset()) {
             revert Errors.InvalidStrategyAsset();
         }
 

--- a/src/module/YieldAggregatorVault.sol
+++ b/src/module/YieldAggregatorVault.sol
@@ -610,7 +610,7 @@ abstract contract YieldAggregatorVaultModule is ERC4626Upgradeable, ERC20VotesUp
 
         if (isDeposit) {
             // Do required approval (safely) and deposit
-            IERC20(IERC4626(address(this)).asset()).safeIncreaseAllowance(_strategy, amountToRebalance);
+            IERC20(_asset()).safeIncreaseAllowance(_strategy, amountToRebalance);
             IERC4626(_strategy).deposit(amountToRebalance, address(this));
             $.strategies[_strategy].allocated = (strategyData.allocated + amountToRebalance).toUint120();
             $.totalAllocated += amountToRebalance;


### PR DESCRIPTION
**Merge after #62**

Implemented `_getInheritedERC4626Storage()` to be able to access `ERC4626Upgradeable.ERC4626Storage` and read `$._asset` through `_asset()` function.