### PR TITLE
Feat: configurable smearing period

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -23,7 +23,7 @@ ignore = [
 
 [profile.test]
 no_match_test = "(Fuzz|invariant_)"
-no_match_contract = "(Fuzz|CryticERC4626TestsHarness|Symbolic)"
+no_match_contract = "(Fuzz|CryticERC4626TestsHarness|Symbolic|Invariants)"
 gas_reports = ["*"]
 
 [profile.fuzz]
@@ -61,7 +61,7 @@ match_test = "invariant_"
 [profile.coverage]
 via_ir = true
 no_match_test = "(invariant_)"
-no_match_contract = "(Script|CryticERC4626TestsHarness|Symbolic)"
+no_match_contract = "(Script|CryticERC4626TestsHarness|Symbolic|Invariants)"
 no_match_coverage= "(script|test|fuzz|e2e)"
 
 [profile.coverage.optimizer_details]

--- a/src/EulerEarn.sol
+++ b/src/EulerEarn.sol
@@ -78,6 +78,8 @@ contract EulerEarn is Dispatch, AccessControlEnumerableUpgradeable, IEulerEarn {
         });
         $.totalAllocationPoints = _initParams.initialCashAllocationPoints;
 
+        $.smearingPeriod = _initParams.smearingPeriod;
+
         // Setup DEFAULT_ADMIN
         _grantRole(DEFAULT_ADMIN_ROLE, _initParams.eulerEarnVaultOwner);
 
@@ -592,6 +594,10 @@ contract EulerEarn is Dispatch, AccessControlEnumerableUpgradeable, IEulerEarn {
     /// @dev See {EulerEarnVaultModule-isCheckingHarvestCoolDown}.
     function isCheckingHarvestCoolDown() public view override (IEulerEarn, EulerEarnVaultModule) returns (bool) {
         return super.isCheckingHarvestCoolDown();
+    }
+
+    function interestSmearingPeriod() public view override (IEulerEarn, EulerEarnVaultModule) returns (uint256) {
+        return super.interestSmearingPeriod();
     }
 
     /// @dev See {EulerEarnVaultModule-permit2Address}.

--- a/src/EulerEarn.sol
+++ b/src/EulerEarn.sol
@@ -65,8 +65,8 @@ contract EulerEarn is Dispatch, AccessControlEnumerableUpgradeable, IEulerEarn {
 
         // Make sure the asset is a contract. Token transfers using a library will not revert if address has no code.
         require(_initParams.asset.code.length != 0, Errors.InvalidAssetAddress());
-
         require(_initParams.initialCashAllocationPoints != 0, Errors.InitialAllocationPointsZero());
+        require(_initParams.smearingPeriod >= Constants.MIN_INTEREST_SMEAR_PERIOD, Errors.InvalidSmearingPeriod());
 
         EulerEarnStorage storage $ = Storage._getEulerEarnStorage();
         $.locked = Constants.REENTRANCYLOCK__UNLOCKED;

--- a/src/EulerEarn.sol
+++ b/src/EulerEarn.sol
@@ -596,6 +596,7 @@ contract EulerEarn is Dispatch, AccessControlEnumerableUpgradeable, IEulerEarn {
         return super.isCheckingHarvestCoolDown();
     }
 
+    /// @dev See {EulerEarnVaultModule-interestSmearingPeriod}.
     function interestSmearingPeriod() public view override (IEulerEarn, EulerEarnVaultModule) returns (uint256) {
         return super.interestSmearingPeriod();
     }

--- a/src/EulerEarnFactory.sol
+++ b/src/EulerEarnFactory.sol
@@ -40,7 +40,8 @@ contract EulerEarnFactory is IEulerEarnFactory {
         address _asset,
         string memory _name,
         string memory _symbol,
-        uint256 _initialCashAllocationPoints
+        uint256 _initialCashAllocationPoints,
+        uint256 _smearingPeriod
     ) external returns (address) {
         address eulerEulerEarnVault = Clones.clone(eulerEarnImpl);
 
@@ -49,7 +50,8 @@ contract EulerEarnFactory is IEulerEarnFactory {
             asset: _asset,
             name: _name,
             symbol: _symbol,
-            initialCashAllocationPoints: _initialCashAllocationPoints
+            initialCashAllocationPoints: _initialCashAllocationPoints,
+            smearingPeriod: _smearingPeriod
         });
         IEulerEarn(eulerEulerEarnVault).init(eulerEarnVaultInitParams);
 

--- a/src/EulerEarnFactory.sol
+++ b/src/EulerEarnFactory.sol
@@ -35,6 +35,7 @@ contract EulerEarnFactory is IEulerEarnFactory {
     /// @param _name Earn vault name.
     /// @param _symbol Earn vault symbol.
     /// @param _initialCashAllocationPoints The amount of points to initally allocate for cash reserve.
+    /// @param _smearingPeriod The period on which the harvested positive yield is smeared to depositors as interest.
     /// @return The address of the new deployed euler earn.
     function deployEulerEarn(
         address _asset,

--- a/src/EulerEarnFactory.sol
+++ b/src/EulerEarnFactory.sol
@@ -35,7 +35,7 @@ contract EulerEarnFactory is IEulerEarnFactory {
     /// @param _name Earn vault name.
     /// @param _symbol Earn vault symbol.
     /// @param _initialCashAllocationPoints The amount of points to initally allocate for cash reserve.
-    /// @param _smearingPeriod The period on which the harvested positive yield is smeared to depositors as interest.
+    /// @param _smearingPeriod The period during which the harvested positive yield is smeared to depositors as interest.
     /// @return The address of the new deployed euler earn.
     function deployEulerEarn(
         address _asset,

--- a/src/common/Shared.sol
+++ b/src/common/Shared.sol
@@ -110,12 +110,14 @@ abstract contract Shared is EVCUtil {
         uint256 maxGulp = type(uint168).max - interestLeftCached;
         if (toGulp > maxGulp) toGulp = maxGulp; // cap interest, allowing the vault to function
 
+        uint256 smearingPeriodCached = $.smearingPeriod;
+
         interestLeftCached += uint168(toGulp); // toGulp <= maxGulp <= max uint168
         $.lastInterestUpdate = uint40(block.timestamp);
-        $.interestSmearEnd = uint40(block.timestamp + $.smearingPeriod);
+        $.interestSmearEnd = uint40(block.timestamp + smearingPeriodCached);
         $.interestLeft = interestLeftCached;
 
-        emit Events.Gulp(interestLeftCached, block.timestamp + $.smearingPeriod);
+        emit Events.Gulp(interestLeftCached, block.timestamp + smearingPeriodCached);
     }
 
     /// @dev update accrued interest.

--- a/src/common/Shared.sol
+++ b/src/common/Shared.sol
@@ -112,10 +112,10 @@ abstract contract Shared is EVCUtil {
 
         interestLeftCached += uint168(toGulp); // toGulp <= maxGulp <= max uint168
         $.lastInterestUpdate = uint40(block.timestamp);
-        $.interestSmearEnd = uint40(block.timestamp + Constants.INTEREST_SMEAR);
+        $.interestSmearEnd = uint40(block.timestamp + $.smearingPeriod);
         $.interestLeft = interestLeftCached;
 
-        emit Events.Gulp(interestLeftCached, block.timestamp + Constants.INTEREST_SMEAR);
+        emit Events.Gulp(interestLeftCached, block.timestamp + $.smearingPeriod);
     }
 
     /// @dev update accrued interest.

--- a/src/interface/IEulerEarn.sol
+++ b/src/interface/IEulerEarn.sol
@@ -24,6 +24,7 @@ interface IEulerEarn {
         string name;
         string symbol;
         uint256 initialCashAllocationPoints;
+        uint256 smearingPeriod;
     }
 
     /// @dev A struct that hold a strategy allocation's config
@@ -127,4 +128,5 @@ interface IEulerEarn {
     function permit2Address() external view returns (address);
     function EVC() external view returns (address);
     function isCheckingHarvestCoolDown() external view returns (bool);
+    function interestSmearingPeriod() external view returns (uint256);
 }

--- a/src/interface/IEulerEarnFactory.sol
+++ b/src/interface/IEulerEarnFactory.sol
@@ -6,7 +6,8 @@ interface IEulerEarnFactory {
         address _asset,
         string memory _name,
         string memory _symbol,
-        uint256 _initialCashAllocationPoints
+        uint256 _initialCashAllocationPoints,
+        uint256 _smearingPeriod
     ) external returns (address);
 
     function eulerEarnImpl() external view returns (address);

--- a/src/lib/ConstantsLib.sol
+++ b/src/lib/ConstantsLib.sol
@@ -15,14 +15,14 @@ library ConstantsLib {
     uint8 internal constant REENTRANCYLOCK__UNLOCKED = 1;
     uint8 internal constant REENTRANCYLOCK__LOCKED = 2;
 
+    /// @dev The maximum performance fee the vault can have is 50%
+    uint96 internal constant MAX_PERFORMANCE_FEE = 0.5e18;
+
     /// @dev Interest rate smearing period
-    // uint256 public constant INTEREST_SMEAR = 2 weeks;
+    uint256 public constant MIN_INTEREST_SMEAR_PERIOD = 1 days;
 
     /// @dev Cool down period for harvest call during withdraw operation.
     uint256 public constant HARVEST_COOLDOWN = 1 days;
-
-    /// @dev The maximum performance fee the vault can have is 50%
-    uint96 internal constant MAX_PERFORMANCE_FEE = 0.5e18;
 
     /// @dev address(0) set for cash reserve strategy.
     address public constant CASH_RESERVE = address(0);

--- a/src/lib/ConstantsLib.sol
+++ b/src/lib/ConstantsLib.sol
@@ -16,7 +16,7 @@ library ConstantsLib {
     uint8 internal constant REENTRANCYLOCK__LOCKED = 2;
 
     /// @dev Interest rate smearing period
-    uint256 public constant INTEREST_SMEAR = 2 weeks;
+    // uint256 public constant INTEREST_SMEAR = 2 weeks;
 
     /// @dev Cool down period for harvest call during withdraw operation.
     uint256 public constant HARVEST_COOLDOWN = 1 days;

--- a/src/lib/ConstantsLib.sol
+++ b/src/lib/ConstantsLib.sol
@@ -18,7 +18,7 @@ library ConstantsLib {
     /// @dev The maximum performance fee the vault can have is 50%
     uint96 internal constant MAX_PERFORMANCE_FEE = 0.5e18;
 
-    /// @dev Interest smearing period
+    /// @dev Min period for interest smearing
     uint256 public constant MIN_INTEREST_SMEAR_PERIOD = 1 days;
 
     /// @dev Cool down period for harvest call during withdraw operation.

--- a/src/lib/ConstantsLib.sol
+++ b/src/lib/ConstantsLib.sol
@@ -18,7 +18,7 @@ library ConstantsLib {
     /// @dev The maximum performance fee the vault can have is 50%
     uint96 internal constant MAX_PERFORMANCE_FEE = 0.5e18;
 
-    /// @dev Interest rate smearing period
+    /// @dev Interest smearing period
     uint256 public constant MIN_INTEREST_SMEAR_PERIOD = 1 days;
 
     /// @dev Cool down period for harvest call during withdraw operation.

--- a/src/lib/ErrorsLib.sol
+++ b/src/lib/ErrorsLib.sol
@@ -27,6 +27,7 @@ library ErrorsLib {
     error NotEnoughAssets();
     error MaxStrategiesExceeded();
     error InvalidAssetAddress();
+    error InvalidSmearingPeriod();
 
     /// ERC4626Upgradeable.sol errors
     /// @dev Attempted to withdraw more assets than the max amount for `owner`.

--- a/src/lib/StorageLib.sol
+++ b/src/lib/StorageLib.sol
@@ -44,8 +44,7 @@ struct EulerEarnStorage {
     uint32 hookedFns;
 
     /// Last harvest timestamp, this is only updated when a harvest is explicitly called,
-    /// Or when a harvest is executed while withdrawing or redeeming. An executed harvest during `rebalance()`
-    /// does not update this timestamp as rebalance do not guarantee a harvest of all the withdrawal queue strategies.
+    /// Or when a harvest is executed while rebalancing, withdrawing or redeeming.
     uint40 lastHarvestTimestamp;
 }
 

--- a/src/lib/StorageLib.sol
+++ b/src/lib/StorageLib.sol
@@ -32,7 +32,7 @@ struct EulerEarnStorage {
     /// locked: lock for re-entrancy guard.
     uint8 locked;
     
-    /// @dev The period where the harvested positive yield is distributed as interest.
+    /// @dev The period on which the harvested positive yield is smeared to depositors as interest.
     uint256 smearingPeriod;
 
     /// A mapping to check if a user address enabled balance forwarding for reward streams integration.
@@ -43,8 +43,8 @@ struct EulerEarnStorage {
     address hooksTarget;
     uint32 hookedFns;
 
-    /// Last harvest timestamp, this is only updated when a harvest is explicitly called,
-    /// Or when a harvest is executed while rebalancing, withdrawing or redeeming.
+    /// Last harvest timestamp, this is updated when a harvest is explicitly called,
+    /// or when a harvest is executed while rebalancing, withdrawing or redeeming.
     uint40 lastHarvestTimestamp;
 }
 

--- a/src/lib/StorageLib.sol
+++ b/src/lib/StorageLib.sol
@@ -32,7 +32,7 @@ struct EulerEarnStorage {
     /// locked: lock for re-entrancy guard.
     uint8 locked;
     
-    /// @dev The period on which the harvested positive yield is smeared to depositors as interest.
+    /// @dev The period during which the harvested positive yield is smeared to depositors as interest.
     uint256 smearingPeriod;
 
     /// A mapping to check if a user address enabled balance forwarding for reward streams integration.

--- a/src/lib/StorageLib.sol
+++ b/src/lib/StorageLib.sol
@@ -32,7 +32,9 @@ struct EulerEarnStorage {
     /// locked: lock for re-entrancy guard.
     uint8 locked;
     
-    
+    /// @dev The period where the harvested positive yield is distributed as interest.
+    uint256 smearingPeriod;
+
     /// A mapping to check if a user address enabled balance forwarding for reward streams integration.
     mapping(address => bool) isBalanceForwarderEnabled;
     

--- a/src/module/EulerEarnVault.sol
+++ b/src/module/EulerEarnVault.sol
@@ -472,6 +472,12 @@ abstract contract EulerEarnVaultModule is ERC4626Upgradeable, ERC20VotesUpgradea
         return isHarvestCoolDownCheckOn;
     }
 
+    function interestSmearingPeriod() public view virtual returns (uint256) {
+        EulerEarnStorage storage $ = Storage._getEulerEarnStorage();
+
+        return $.smearingPeriod;
+    }
+
     /// @notice Return the address of Permit2 contract.
     /// @dev Not protected with `nonReentrantView()`.
     /// @return Permit2 address.

--- a/src/module/EulerEarnVault.sol
+++ b/src/module/EulerEarnVault.sol
@@ -472,6 +472,9 @@ abstract contract EulerEarnVaultModule is ERC4626Upgradeable, ERC20VotesUpgradea
         return isHarvestCoolDownCheckOn;
     }
 
+    /// @notice Return the smearing period.
+    /// @dev Not protected with `nonReentrantView()`.
+    /// @return Smearing period.
     function interestSmearingPeriod() public view virtual returns (uint256) {
         EulerEarnStorage storage $ = Storage._getEulerEarnStorage();
 

--- a/test/A16zPropertyTests.t.sol
+++ b/test/A16zPropertyTests.t.sol
@@ -70,7 +70,7 @@ contract A16zPropertyTests is ERC4626Test {
 
         _underlying_ = address(new ERC20Mock());
         _vault_ = eulerEulerEarnVaultFactory.deployEulerEarn(
-            _underlying_, "E20M_Agg", "E20M_Agg", CASH_RESERVE_ALLOCATION_POINTS
+            _underlying_, "E20M_Agg", "E20M_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
         );
         _delta_ = 0;
         _vaultMayBeEmpty = false;

--- a/test/common/EulerEarnBase.t.sol
+++ b/test/common/EulerEarnBase.t.sol
@@ -80,7 +80,7 @@ contract EulerEarnBase is EVaultTestBase {
         eulerEulerEarnVaultFactory = new EulerEarnFactory(eulerEarnImpl);
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
 
@@ -161,7 +161,7 @@ contract EulerEarnBase is EVaultTestBase {
 
     function testDeployEulerEarnWithInvalidInitialCashAllocationPoints() public {
         vm.expectRevert(ErrorsLib.InitialAllocationPointsZero.selector);
-        eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 0);
+        eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 0, 2 weeks);
     }
 
     function _addStrategy(address from, address strategy, uint256 allocationPoints) internal {

--- a/test/common/EulerEarnBase.t.sol
+++ b/test/common/EulerEarnBase.t.sol
@@ -164,10 +164,10 @@ contract EulerEarnBase is EVaultTestBase {
         eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 0, 2 weeks);
     }
 
-    // function testDeployEulerEarnWithInvalidSmearingPeriod() public {
-    //     vm.expectRevert(ErrorsLib.InvalidSmearingPeriod.selector);
-    //     eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 100, 2);
-    // }
+    function testDeployEulerEarnWithInvalidSmearingPeriod() public {
+        vm.expectRevert(ErrorsLib.InvalidSmearingPeriod.selector);
+        eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 100, 2);
+    }
 
     function _addStrategy(address from, address strategy, uint256 allocationPoints) internal {
         vm.prank(from);

--- a/test/common/EulerEarnBase.t.sol
+++ b/test/common/EulerEarnBase.t.sol
@@ -164,6 +164,11 @@ contract EulerEarnBase is EVaultTestBase {
         eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 0, 2 weeks);
     }
 
+    // function testDeployEulerEarnWithInvalidSmearingPeriod() public {
+    //     vm.expectRevert(ErrorsLib.InvalidSmearingPeriod.selector);
+    //     eulerEulerEarnVaultFactory.deployEulerEarn(address(assetTST), "assetTST_Agg", "assetTST_Agg", 100, 2);
+    // }
+
     function _addStrategy(address from, address strategy, uint256 allocationPoints) internal {
         vm.prank(from);
         eulerEulerEarnVault.addStrategy(strategy, allocationPoints);

--- a/test/e2e/BalanceForwarderE2ETest.t.sol
+++ b/test/e2e/BalanceForwarderE2ETest.t.sol
@@ -43,7 +43,7 @@ contract BalanceForwarderE2ETest is EulerEarnBase {
 
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
 

--- a/test/e2e/StrategyRewardsE2ETest.t.sol
+++ b/test/e2e/StrategyRewardsE2ETest.t.sol
@@ -96,7 +96,7 @@ contract StrategyRewardsE2ETest is EulerEarnBase {
         eulerEulerEarnVaultFactory = new EulerEarnFactory(eulerEarnImpl);
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
 

--- a/test/echidna/CryticERC4626TestsHarness.t.sol
+++ b/test/echidna/CryticERC4626TestsHarness.t.sol
@@ -79,7 +79,7 @@ contract CryticERC4626TestsHarness is
 
         TestERC20Token _asset = new TestERC20Token("Test Token", "TT", 18);
         address _vault = eulerEulerEarnVaultFactory.deployEulerEarn(
-            address(_asset), "TT_Agg", "TT_Agg", CASH_RESERVE_ALLOCATION_POINTS
+            address(_asset), "TT_Agg", "TT_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
         );
 
         initialize(address(_vault), address(_asset), false);

--- a/test/fuzz/GulpFuzzTest.t.sol
+++ b/test/fuzz/GulpFuzzTest.t.sol
@@ -73,7 +73,7 @@ contract GulpFuzzTest is EulerEarnBase {
         // Mint interest directly into the contract
         assetTST.mint(address(eulerEulerEarnVault), interestAmount);
         eulerEulerEarnVault.gulp();
-        skip(ConstantsLib.INTEREST_SMEAR);
+        skip(eulerEulerEarnVault.interestSmearingPeriod());
 
         (,, uint168 interestLeft) = eulerEulerEarnVault.getEulerEarnSavingRate();
         assertEq(eulerEulerEarnVault.totalAssets(), depositAmount + interestAmount);

--- a/test/invariant/EulerEarnInvariants.t.sol
+++ b/test/invariant/EulerEarnInvariants.t.sol
@@ -22,6 +22,31 @@ contract EulerEarnInvariants is EulerEarnBase {
     function setUp() public override {
         super.setUp();
 
+        vm.startPrank(deployer);
+
+        eulerEulerEarnVault = EulerEarn(
+            eulerEulerEarnVaultFactory.deployEulerEarn(
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 1 days
+            )
+        );
+
+        // grant admin roles to deployer
+        eulerEulerEarnVault.grantRole(ConstantsLib.GUARDIAN_ADMIN, deployer);
+        eulerEulerEarnVault.grantRole(ConstantsLib.STRATEGY_OPERATOR_ADMIN, deployer);
+        eulerEulerEarnVault.grantRole(ConstantsLib.EULER_EARN_MANAGER_ADMIN, deployer);
+        eulerEulerEarnVault.grantRole(ConstantsLib.WITHDRAWAL_QUEUE_MANAGER_ADMIN, deployer);
+        eulerEulerEarnVault.grantRole(ConstantsLib.REBALANCER_ADMIN, deployer);
+
+        // grant roles to manager
+        eulerEulerEarnVault.grantRole(ConstantsLib.GUARDIAN, manager);
+        eulerEulerEarnVault.grantRole(ConstantsLib.STRATEGY_OPERATOR, manager);
+        eulerEulerEarnVault.grantRole(ConstantsLib.EULER_EARN_MANAGER, manager);
+        eulerEulerEarnVault.grantRole(ConstantsLib.WITHDRAWAL_QUEUE_MANAGER, manager);
+        eulerEulerEarnVault.grantRole(ConstantsLib.REBALANCER, manager);
+
+        vm.stopPrank();
+        vm.label(address(eulerEulerEarnVault), "eulerEulerEarnVault");
+
         actorUtil = new ActorUtil(address(eulerEulerEarnVault));
         actorUtil.includeActor(manager);
         actorUtil.includeActor(deployer);

--- a/test/invariant/EulerEarnInvariants.t.sol
+++ b/test/invariant/EulerEarnInvariants.t.sol
@@ -23,7 +23,6 @@ contract EulerEarnInvariants is EulerEarnBase {
         super.setUp();
 
         vm.startPrank(deployer);
-
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
                 address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 1 days
@@ -43,8 +42,8 @@ contract EulerEarnInvariants is EulerEarnBase {
         eulerEulerEarnVault.grantRole(ConstantsLib.EULER_EARN_MANAGER, manager);
         eulerEulerEarnVault.grantRole(ConstantsLib.WITHDRAWAL_QUEUE_MANAGER, manager);
         eulerEulerEarnVault.grantRole(ConstantsLib.REBALANCER, manager);
-
         vm.stopPrank();
+
         vm.label(address(eulerEulerEarnVault), "eulerEulerEarnVault");
 
         actorUtil = new ActorUtil(address(eulerEulerEarnVault));

--- a/test/invariant/EulerEarnInvariants.t.sol
+++ b/test/invariant/EulerEarnInvariants.t.sol
@@ -59,7 +59,7 @@ contract EulerEarnInvariants is EulerEarnBase {
     // totalAssetsDeposited should be equal to the totalAssetsAllocatable after SMEAR has passed.
     function invariant_totalAssets() public {
         eulerEulerEarnVault.gulp();
-        skip(ConstantsLib.INTEREST_SMEAR); // make sure smear has passed
+        skip(eulerEulerEarnVault.interestSmearingPeriod()); // make sure smear has passed
         eulerEulerEarnVault.updateInterestAccrued();
 
         if (eulerEulerEarnVault.totalSupply() > 0) {

--- a/test/invariant/EulerEarnInvariants.t.sol
+++ b/test/invariant/EulerEarnInvariants.t.sol
@@ -25,7 +25,7 @@ contract EulerEarnInvariants is EulerEarnBase {
         vm.startPrank(deployer);
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 1 days
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 3 days
             )
         );
 

--- a/test/symbolic-test/EulerEarnSymbolicTest.t.sol
+++ b/test/symbolic-test/EulerEarnSymbolicTest.t.sol
@@ -102,7 +102,7 @@ contract EulerEarnSymbolicTest is EulerEarnBase, SymTest {
 
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
         // grant admin roles to deployer

--- a/test/unit/BalanceForwarderTest.t.sol
+++ b/test/unit/BalanceForwarderTest.t.sol
@@ -13,7 +13,7 @@ contract BalanceForwarderTest is EulerEarnBase {
 
         eulerEulerEarnVaultNoTracker = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
 
@@ -47,7 +47,7 @@ contract BalanceForwarderTest is EulerEarnBase {
 
         eulerEulerEarnVault = EulerEarn(
             eulerEulerEarnVaultFactory.deployEulerEarn(
-                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS
+                address(assetTST), "assetTST_Agg", "assetTST_Agg", CASH_RESERVE_ALLOCATION_POINTS, 2 weeks
             )
         );
 


### PR DESCRIPTION
Allow Earn vault deployer to set smearing period.
A minimum required period of 1 day.