### PR TITLE
feat: skim()

### DIFF
--- a/src/EulerEarn.sol
+++ b/src/EulerEarn.sol
@@ -190,6 +190,15 @@ contract EulerEarn is Dispatch, AccessControlEnumerableUpgradeable, IEulerEarn {
         use(hooksModule)
     {}
 
+    /// @dev See {EulerEarnVaultModule-skim}.
+    function skim(address _token, address _recipient)
+        public
+        override (IEulerEarn, EulerEarnVaultModule)
+        onlyEVCAccountOwner
+        onlyRole(Constants.EULER_EARN_MANAGER)
+        use(eulerEarnVaultModule)
+    {}
+
     /// @dev See {StrategyModule-addStrategy}.
     function addStrategy(address _strategy, uint256 _allocationPoints)
         public

--- a/src/interface/IEulerEarn.sol
+++ b/src/interface/IEulerEarn.sol
@@ -84,6 +84,7 @@ interface IEulerEarn {
     function delegate(address _delegatee) external;
     function delegateBySig(address _delegatee, uint256 _nonce, uint256 _expiry, uint8 _v, bytes32 _r, bytes32 _s)
         external;
+    function skim(address _token, address _recipient) external;
 
     /// view functions
     function interestAccrued() external view returns (uint256);

--- a/src/lib/ErrorsLib.sol
+++ b/src/lib/ErrorsLib.sol
@@ -28,6 +28,7 @@ library ErrorsLib {
     error MaxStrategiesExceeded();
     error InvalidAssetAddress();
     error InvalidSmearingPeriod();
+    error CanNotSkim();
 
     /// ERC4626Upgradeable.sol errors
     /// @dev Attempted to withdraw more assets than the max amount for `owner`.

--- a/src/lib/EventsLib.sol
+++ b/src/lib/EventsLib.sol
@@ -13,6 +13,7 @@ library EventsLib {
     event Harvest(uint256 totalAllocated, uint256 totalYield, uint256 totalLoss);
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
     event Rebalance(address indexed strategy, uint256 amountToRebalance, bool isDeposit);
+    event Skim(address indexed token, address indexed recipient, uint256 amount);
 
     /// @dev Strategy.sol events
     event AdjustAllocationPoints(address indexed strategy, uint256 oldPoints, uint256 newPoints);

--- a/src/module/EulerEarnVault.sol
+++ b/src/module/EulerEarnVault.sol
@@ -53,6 +53,20 @@ abstract contract EulerEarnVaultModule is ERC4626Upgradeable, ERC20VotesUpgradea
         }
     }
 
+    /// @notice Skim any asset from Earn vault, other than the vault's underlying asset.
+    /// @dev Can only be called by address with the role `EULER_EARN_MANAGER`.
+    /// @param _token Token address to skim.
+    /// @param _recipient Recipient address.
+    function skim(address _token, address _recipient) external {
+        require(_token != _asset(), Errors.CanNotSkim());
+
+        uint256 amount = IERC20(_token).balanceOf(address(this));
+
+        IERC20(_token).safeTransfer(_recipient, amount);
+
+        emit Events.Skim(_token, _recipient, amount);
+    }
+
     /// @notice Harvest all the strategies.
     /// @dev    When harvesting a net negative yield amount, the loss amount will be instantly deducted,
     ///         and this will drop the vault's share price. Therefore, Euler Earn shares should never be used as collateral in any other protocol.

--- a/src/module/EulerEarnVault.sol
+++ b/src/module/EulerEarnVault.sol
@@ -57,7 +57,7 @@ abstract contract EulerEarnVaultModule is ERC4626Upgradeable, ERC20VotesUpgradea
     /// @dev Can only be called by address with the role `EULER_EARN_MANAGER`.
     /// @param _token Token address to skim.
     /// @param _recipient Recipient address.
-    function skim(address _token, address _recipient) external {
+    function skim(address _token, address _recipient) external virtual nonReentrant {
         require(_token != _asset(), Errors.CanNotSkim());
 
         uint256 amount = IERC20(_token).balanceOf(address(this));


### PR DESCRIPTION
Added `skim()` function that can only be called by an address with `EULER_EARN_MANAGER` role.

This function will help re-distribute rewards from custom reward-mechanism contracts that are not explicitly integrated with Earn.